### PR TITLE
Added some meta tags to base template

### DIFF
--- a/podship/engine/templates/base.html
+++ b/podship/engine/templates/base.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% block page_title %}{% end %}</title>
         {% block page_head %}{% end %}
 

--- a/podship/gateway/templates/base.html
+++ b/podship/gateway/templates/base.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% block page_title %}{% end %}</title>
         {% block page_head %}{% end %}
 

--- a/podship/platform/templates/base.html
+++ b/podship/platform/templates/base.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Podship Platform Test</title>
         {% block page_head %}{% end %}
 

--- a/podship/pod/templates/base.html
+++ b/podship/pod/templates/base.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% block page_title %}{% end %}</title>
         {% block page_head %}{% end %}
 

--- a/podship/pod/templates/login_base.html
+++ b/podship/pod/templates/login_base.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% block page_title %}{% end %}</title>
         {% block page_head %}{% end %}
 


### PR DESCRIPTION
The first tag adds the charset info. The second forces the browser render at whatever the most recent version's standards are, and the third will instruct the browser to render the width of the page at the width of its own screen, for responsive design purposes.
